### PR TITLE
Fix: Resolve 'ModuleNotFoundError: No module named 'AudioLib'' issue

### DIFF
--- a/tests/effects.py
+++ b/tests/effects.py
@@ -7,6 +7,9 @@
     Note   : Please change the code below to fit your needs.
 '''
 
+import sys
+sys.path.append('<path>/PythonAudioEffects')
+# EXAMPLE: In my case it was, sys.path.append('/home/pixel22/Projects/PythonAudioEffects')
 from AudioLib import AudioEffect
 
 input_file_path = 'input.wav'

--- a/tests/processing.py
+++ b/tests/processing.py
@@ -7,6 +7,10 @@
     Note   : Please change the code below to fit your needs.
 '''
 
+import sys
+sys.path.append('<path>/PythonAudioEffects')
+# EXAMPLE: In my case it was, sys.path.append('/home/pixel22/Projects/PythonAudioEffects')
+from AudioLib import AudioEffect
 from AudioLib.AudioProcessing import AudioProcessing
 
 sound1 = AudioProcessing('input.wav')


### PR DESCRIPTION
I think the error is occurring because the Python interpreter is unable to find the AudioLib module. To resolve this issue, you can modify the sys.path list in your Python script to include the directory containing the AudioLib package.

Fix #1 