### PR TITLE
Fix: Resolve "IndexError: invalid index to scalar variable" issue

### DIFF
--- a/AudioLib/AudioProcessing.py
+++ b/AudioLib/AudioProcessing.py
@@ -134,11 +134,16 @@ class AudioProcessing(object):
 
 	@staticmethod
 	def convert_to_mono_audio(input_audio):
-		'''Returns a numpy array that represents the mono version of a stereo input'''
-		output_audio = []
-		temp_audio = input_audio.astype(float)
+		'''Returns a numpy array that represents the mono version of input audio'''
+		if input_audio.ndim == 1 or input_audio.shape[1] == 1:
+			# If the input is already mono, return it as is
+			output_audio = np.array(input_audio, dtype='float32')
+		elif input_audio.shape[1] == 2:
+			# If the input is stereo, convert it to mono (average both channels)
+			output_audio = np.mean(input_audio, axis=1)
+		else:
+			# For more than two channels, choose a strategy to handle multi-channel audio
+			# Here, simply take the first channel and discard the rest
+			output_audio = input_audio[:, 0]
 
-		for e in temp_audio:
-			output_audio.append((e[0] / 2) + (e[1] / 2))
-
-		return np.array(output_audio, dtype = 'int16')
+		return output_audio

--- a/tests/effects.py
+++ b/tests/effects.py
@@ -7,6 +7,9 @@
     Note   : Please change the code below to fit your needs.
 '''
 
+import sys
+sys.path.append('<path>/PythonAudioEffects')
+# EXAMPLE: In my case it was, sys.path.append('/home/pixel22/Projects/PythonAudioEffects')
 from AudioLib import AudioEffect
 
 input_file_path = 'input.wav'

--- a/tests/processing.py
+++ b/tests/processing.py
@@ -7,6 +7,10 @@
     Note   : Please change the code below to fit your needs.
 '''
 
+import sys
+sys.path.append('<path>/PythonAudioEffects')
+# EXAMPLE: In my case it was, sys.path.append('/home/pixel22/Projects/PythonAudioEffects')
+from AudioLib import AudioEffect
 from AudioLib.AudioProcessing import AudioProcessing
 
 sound1 = AudioProcessing('input.wav')


### PR DESCRIPTION
I think the error was caused because the code was written to handle stereo (two-channel) audio data, while the input audio files were mono (single-channel), resulting in an attempt to access non-existent indices for the second channel.

To handle different types of audio formats (mono or stereo) within the convert_to_mono_audio method, you can modify it to check the number of channels and perform different actions accordingly.

Fix #5 